### PR TITLE
fix: 초기 리뷰 상태 처리 개선

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ const run = async (): Promise<void> => {
 
     const [previousReviewState, lastReviewState] = reviewList.slice(-2).map((review) => review.state as ReviewState);
 
-    if (!lastReviewState) {
+    if (!previousReviewState && !lastReviewState) {
       logger.error('Last review state is undefined. Action cannot proceed.');
 
       return;
@@ -45,8 +45,8 @@ const run = async (): Promise<void> => {
 
     await processReviewState({
       token,
-      reviewState: lastReviewState,
-      previousReviewState: previousReviewState,
+      reviewState: lastReviewState ?? previousReviewState,
+      previousReviewState: previousReviewState ?? DEFAULT_REVIEW_STATE,
       parseLabel,
       allLabelList,
       deleteLabelPattern,


### PR DESCRIPTION
###### 기능 개발용 `downstream/feature-branch` to `upstream/dev`

## 리뷰 요약 정보

- 예상 리뷰 소요 시간: e.g., 5분, 30분
- 희망 리뷰 마감 기한: e.g., 이번주 수요일 오전

## 주요 변경점

- 2개 미만의 값에 사용하는 slice(-2) 의 버그를 수정합니다


## 검토자가 알아야 할 사항

- ![image](https://github.com/user-attachments/assets/f8eb485a-5a12-42b8-893b-91c1687581dc)
 리뷰가 하나만 있을 때 발생하던 문제를 해결합니다.

reviewList 가 갯수가 2개 미만 일 경우 slice(-2) 케이스 중 항상 lastReviewState 가 falsy 이기에 폴백처리를 진행합니다.

