### PR TITLE
Adds option to skip action based on reviewer name

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@
 
 ## Inputs
 
-| 값                    | 설명                                                                   | 필수여부 |
-|----------------------|----------------------------------------------------------------------|------|
-| `token`              | GitHub에서 제공하는 토큰.                                                    | O    |
-| `label`              | 각 review state의 조건에 따라 부착되는 라벨의 값 approve / comment / request change | O    |
-| `deleteLabelPattern` | 일률적으로 삭제를 시킬 라벨의 glob pattern                                        | X    |
+| 값                         | 설명                                                                   | 필수여부 |
+|---------------------------|----------------------------------------------------------------------|------|
+| `token`                   | GitHub에서 제공하는 토큰.                                                    | O    |
+| `label`                   | 각 review state의 조건에 따라 부착되는 라벨의 값 approve / comment / request change | O    |
+| `deleteLabelPattern`      | 일률적으로 삭제를 시킬 라벨의 glob pattern                                        | X    |
+| `skipReviewerNamePattern` | glob를 사용하여 해당 액션을 실행 시키지 않을 리뷰어 이름 패턴입니다.                            | X    |
 
 ### label
 
@@ -45,7 +46,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: pr-auto-state-label
-        uses: ./
+        uses: jiro-developers/pr-auto-state-label@latest
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           label: >

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
   deleteLabelPattern:
     description: "glob를 사용하여 삭제를 할 라벨 패턴입니다."
     required: false
+  skipReviewerNamePattern:
+    description: "glob를 사용하여 해당 액션을 실행 시키지 않을 리뷰어 이름 패턴입니다."
+    required: false
+
 
 runs:
   using: "node16"

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -17,6 +17,7 @@ const REQUIRED_ACTION_INPUT_KEY_LIST: RequiredActionInputKey[] = [
 
 const OPTIONAL_ACTION_INPUT_KEY_LIST: OptionalActionInputKey[] = [
   'deleteLabelPattern', // globPattern -> 삭제하지 않을 라벨 목록
+  'skipReviewerNamePattern', // globPattern -> 해당 액션을 실행 시키지 않을 리뷰어 이름 패턴
 ] as const;
 
 const ACTION_INPUT_KEY_LIST: ActionInputKey[] = [...REQUIRED_ACTION_INPUT_KEY_LIST, ...OPTIONAL_ACTION_INPUT_KEY_LIST];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,7 +4,9 @@ type RequiredActionInputKey =
   | 'token' // GitHub Token
   | 'label';
 
-type OptionalActionInputKey = 'deleteLabelPattern'; // globPattern -> 삭제하지 않을 태그 목록
+type OptionalActionInputKey =
+  | 'deleteLabelPattern' // globPattern -> 삭제하지 않을 태그 목록
+  | 'skipReviewerNamePattern'; // globPattern -> 해당 액션을 실행 시키지 않을 리뷰어 이름 패턴
 
 type ActionInputKey = RequiredActionInputKey | OptionalActionInputKey;
 

--- a/src/utils/github/validateGithubInputList.ts
+++ b/src/utils/github/validateGithubInputList.ts
@@ -18,7 +18,7 @@ const validateGithubInputList = () => {
   }
 
   // 입력값에서 필요한 항목을 추출합니다.
-  const { token, label, deleteLabelPattern } = inputList;
+  const { token, label, deleteLabelPattern, skipReviewerNamePattern } = inputList;
   // 라벨 JSON 문자열을 파싱합니다.
   const parseLabel = safeJsonParse<LabelInput>(label);
 
@@ -33,10 +33,11 @@ const validateGithubInputList = () => {
     message: 'Inputs received successfully.',
     label,
     deleteLabelPattern,
+    skipReviewerNamePattern,
   });
 
   // 검증된 입력값을 반환합니다.
-  return { token, parseLabel, deleteLabelPattern };
+  return { token, parseLabel, deleteLabelPattern, skipReviewerNamePattern };
 };
 
 export { validateGithubInputList };


### PR DESCRIPTION
###### 기능 개발용 `downstream/feature-branch` to `upstream/dev`

## 리뷰 요약 정보

- 예상 리뷰 소요 시간: 5분
- 희망 리뷰 마감 기한: 내일 오전

## 주요 변경점

- 사용자가 리뷰어 이름 패턴을 지정하여 특정 리뷰어에 대해 액션 실행을 건너뛸 수 있도록 함
- `action.yml`, `README.md`, `src/constants/common.ts`, `src/index.ts`, `src/types/index.ts`, `src/utils/github/validateGithubInputList.ts` 파일 수정

## 검토자가 알아야 할 사항

- `skipReviewerNamePattern` 입력값을 사용하여 액션이 실행되어서는 안되는 리뷰어 이름을 정의합니다. 이는 특정 사용자에 대해 액션을 선택적으로 비활성화하는 데 유용합니다.